### PR TITLE
Link CI badge to latest main build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHub CI](https://github.com/otis22/vetmanager-url/workflows/CI/badge.svg)
+[![GitHub CI](https://github.com/otis22/vetmanager-url/workflows/CI/badge.svg)](https://github.com/otis22/vetmanager-url/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage Status](https://coveralls.io/repos/github/otis22/vetmanager-url/badge.svg?branch=main)](https://coveralls.io/github/otis22/vetmanager-url?branch=main)
 
 # Vetmanager Url


### PR DESCRIPTION
Make the GitHub CI badge clickable to open the latest build in the `main` branch.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e9e9afb-d271-42b3-8805-0436cade9893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e9e9afb-d271-42b3-8805-0436cade9893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

